### PR TITLE
Fix required properties naming #366

### DIFF
--- a/tooling/camel-k-maven-plugin/src/main/java/org/apache/camel/k/tooling/maven/GenerateYAMLEndpointsSchema.java
+++ b/tooling/camel-k-maven-plugin/src/main/java/org/apache/camel/k/tooling/maven/GenerateYAMLEndpointsSchema.java
@@ -97,11 +97,11 @@ public class GenerateYAMLEndpointsSchema extends GenerateYamlSupport {
         options.stream()
             .sorted(Comparator.comparing(ComponentModel.EndpointOptionModel::getName))
             .forEach(option -> {
+            	String name = StringHelper.camelCaseToDash(option.getName());
                 if (option.isRequired()) {
-                    root.withArray("required").add(option.getName());
+                    root.withArray("required").add(name);
                 }
 
-                String name = StringHelper.camelCaseToDash(option.getName());
                 ObjectNode node = root.with("properties").putObject(name);
 
                 processEndpointOption(node, option);


### PR DESCRIPTION
the same name must be used for the property definition and the list of
required properties. Camel case name was used for required list and
dashed name for definition. Modified to use dashed name always.


Nota: i cannot build the project locally (not related to this PR) so cannot test that it is working fine